### PR TITLE
Enable connecting to mission not instantiated via the concrete instance of LocalSuperMole

### DIFF
--- a/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
@@ -61,6 +61,10 @@ public class LocalSuperMole implements Mole {
                     missionMoles.putIfAbsent(mission, mole);
                 }
 
+                for (MissionInstance missionInstance : state.activeMissions()) {
+                    activeMoles.putIfAbsent(missionInstance.handle(), mole);
+                }
+
                 missionMoles.entrySet().stream()
                         .filter(e -> e.getValue().equals(mole))
                         .map(Map.Entry::getKey)


### PR DESCRIPTION
When a `Mission` was instantiated on a mole managed by `LocalSuperMole` but not via the `LocalSuperMole#instantiate` method, the `LocalSuperMole` didn't have a record about where the `MissionInstance` is running and thus it couldn't control this `Mission`.

This pull request fixes this by adding a `MissionInstance` into the `activeMoles` map when an `AgencyState` update from any of the underlying moles occurs.

### Questions
1. Is this wanted behavior or a bug?