### PR TITLE
[TreeMissionExecutor] Remove the initial STEP_INTO command

### DIFF
--- a/molr-mole-core/src/main/java/io/molr/mole/core/tree/TreeMissionExecutor.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/tree/TreeMissionExecutor.java
@@ -44,13 +44,6 @@ public class TreeMissionExecutor implements MissionExecutor {
                 .cache(1)
                 .sample(Duration.ofMillis(100))
                 .publishOn(Schedulers.elastic());
-
-        Strand rootStrand = strandFactory.rootStrand();
-        StrandExecutor rootExecutor = strandExecutorFactory.createStrandExecutor(rootStrand, treeStructure);
-
-        if (!treeStructure.isLeaf(treeStructure.rootBlock())) {
-            rootExecutor.instruct(STEP_INTO);
-        }
     }
 
     @Deprecated


### PR DESCRIPTION
The execution of the command is asynchronous. When the user already receives the `MissionHandle` from the `Mole`, he still cannot use it to instruct commands because the `Mole` will say that there is a command in progress (even though the user haven't sent any command yet).

This behavior is not compliant with the Mole's docs: At this point in time, commands can be sent to the mission instance through the `instruct(MissionHandle, Strand, StrandCommand)` method.

Removing this should not have a big impoct because as for my understanding the `STEP_INTO` command is there only for convenience in usage because otherwise in most of the cases this might be the first command to be executed by the user.