### PR TITLE
Allow emitting of arrays as outputs

### DIFF
--- a/molr-commons/src/main/java/io/molr/commons/domain/Out.java
+++ b/molr-commons/src/main/java/io/molr/commons/domain/Out.java
@@ -1,5 +1,7 @@
 package io.molr.commons.domain;
 
+import java.util.Collection;
+
 public interface Out {
 
     void emit(String name, Number value);
@@ -8,4 +10,5 @@ public interface Out {
 
     <T> void emit(Placeholder<T> placeholder, T value);
 
+    <T> void emit(Placeholder<T> placeholder, Collection<T> value);
 }

--- a/molr-mole-core/src/main/java/io/molr/mole/core/tree/BlockOutputCollector.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/tree/BlockOutputCollector.java
@@ -1,5 +1,7 @@
 package io.molr.mole.core.tree;
 
+import java.util.Collection;
+
 import io.molr.commons.domain.Block;
 import io.molr.commons.domain.Out;
 import io.molr.commons.domain.Placeholder;
@@ -31,5 +33,9 @@ public class BlockOutputCollector implements Out {
         collector.put(block, placeholder, value);
     }
 
+    @Override
+    public <T> void emit(Placeholder<T> placeholder, Collection<T> value) {
+        collector.put(block, placeholder, value);
+    }
 
 }

--- a/molr-mole-core/src/main/java/io/molr/mole/core/tree/ConcurrentMissionOutputCollector.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/tree/ConcurrentMissionOutputCollector.java
@@ -9,6 +9,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.ReplayProcessor;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -37,6 +38,11 @@ public class ConcurrentMissionOutputCollector implements MissionOutputCollector 
 
     @Override
     public <T> void put(Block block, Placeholder<T> placeholder, T value) {
+        putIt(block, placeholder.name(), value);
+    }
+
+    @Override
+    public <T> void put(Block block, Placeholder<T> placeholder, Collection<T> value) {
         putIt(block, placeholder.name(), value);
     }
 

--- a/molr-mole-core/src/main/java/io/molr/mole/core/tree/MissionOutputCollector.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/tree/MissionOutputCollector.java
@@ -1,5 +1,7 @@
 package io.molr.mole.core.tree;
 
+import java.util.Collection;
+
 import io.molr.commons.domain.Block;
 import io.molr.commons.domain.MissionOutput;
 import io.molr.commons.domain.Placeholder;
@@ -12,6 +14,8 @@ public interface MissionOutputCollector {
     void put(Block block, String name, String value);
 
     <T> void put(Block block, Placeholder<T> placeholder, T value);
+
+    <T> void put(Block block, Placeholder<T> placeholder, Collection<T> value);
 
     Flux<MissionOutput> asStream();
 }


### PR DESCRIPTION
The solution I chose is to extend the `Out` and `MissionOutputCollector` interfaces by adding a method accepting collections of any types allowed by Placeholders.

I preferred this solution over using the `Out#emit(Placeholder<T>, T)` method because `T` would need to be `Class<Collection<String>>`, which I didn't manage to do this in Java. Also on [Stackoverflow](https://stackoverflow.com/a/2012459) I only found a way to create a `Class<List<String>>` but this was very ugly.