### PR TITLE
Add support for Mission Logs

### DIFF
--- a/molr-commons/src/main/java/io/molr/commons/domain/MissionLog.java
+++ b/molr-commons/src/main/java/io/molr/commons/domain/MissionLog.java
@@ -1,0 +1,111 @@
+package io.molr.commons.domain;
+
+import io.molr.commons.domain.dto.MissionLogDto;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+
+public final class MissionLog {
+    private final String time;
+    private final String missionHandle;
+    private final String strandId;
+    private final String blockId;
+    private final String message;
+
+    private MissionLog(Builder builder) {
+        this.time = builder.time;
+        this.missionHandle = builder.handleId;
+        this.strandId = builder.strandId;
+        this.blockId = builder.blockId;
+        this.message = builder.message;
+    }
+
+    public static Builder from(MissionHandle handle) {
+        return new Builder(handle);
+    }
+
+    public String time() {
+        return time;
+    }
+
+    public String missionHandle() {
+        return missionHandle;
+    }
+
+    public String strandId() {
+        return strandId;
+    }
+
+    public String blockId() {
+        return blockId;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return MissionLogDto.from(this).toString();
+    }
+
+    public static class Builder {
+
+        private String handleId;
+        private String time;
+        private String strandId;
+        private String blockId;
+        private String message;
+
+        private Builder(MissionHandle handle) {
+            this.handleId = handle.id();
+            this.time = LocalDateTime.now().toString();
+        }
+
+        public Builder time(String time) {
+            this.time = time;
+            return this;
+        }
+
+        public Builder strand(Strand strand) {
+            this.strandId = strand.id();
+            return this;
+        }
+
+        public Builder strand(String strandId) {
+            this.strandId = strandId;
+            return this;
+        }
+
+        public Builder block(Block block) {
+            this.blockId = block.id();
+            return this;
+        }
+
+        public Builder block(String blockId) {
+            this.blockId = blockId;
+            return this;
+        }
+
+        public Builder message(Exception e, String template, Object... params) {
+            this.message = formatMessage(template, params) + "/n" + e.getStackTrace().toString();
+            return this;
+        }
+
+        public Builder message(String template, Object... params) {
+            this.message = formatMessage(template, params);
+            return this;
+        }
+
+        private String formatMessage(String template, Object... params) {
+            if (params.length > 0) {
+                return MessageFormat.format(template, params);
+            }
+            return template;
+        }
+
+        public MissionLog build() {
+            return new MissionLog(this);
+        }
+    }
+}

--- a/molr-commons/src/main/java/io/molr/commons/domain/dto/MissionLogDto.java
+++ b/molr-commons/src/main/java/io/molr/commons/domain/dto/MissionLogDto.java
@@ -1,0 +1,50 @@
+package io.molr.commons.domain.dto;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionLog;
+
+public class MissionLogDto {
+
+    public final String time;
+    public final String missionHandle;
+    public final String strandId;
+    public final String blockId;
+    public final String message;
+
+    public MissionLogDto(String time, String missionHandle, String strandId, String blockId, String message) {
+        this.time = time;
+        this.missionHandle = missionHandle;
+        this.strandId = strandId;
+        this.blockId = blockId;
+        this.message = message;
+    }
+
+    public MissionLogDto() {
+        this.time = null;
+        this.missionHandle = null;
+        this.strandId = null;
+        this.blockId = null;
+        this.message = null;
+    }
+
+    public static final MissionLogDto from(MissionLog missionLog) {
+        return new MissionLogDto(missionLog.time(), missionLog.missionHandle(), missionLog.strandId(),
+                missionLog.blockId(), missionLog.message());
+    }
+
+    public MissionLog toMissionLog() {
+        return MissionLog.from(MissionHandle.ofId(missionHandle)).time(time).strand(strandId).block(blockId)
+                .message(message).build();
+    }
+
+    @Override
+    public String toString() {
+        return "MissionLogDto{" +
+                "time='" + time + '\'' +
+                ", missionHandle='" + missionHandle + '\'' +
+                ", strandId='" + strandId + '\'' +
+                ", blockId='" + blockId + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/molr-mole-core/build.gradle
+++ b/molr-mole-core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     compile group: 'io.projectreactor', name: 'reactor-core', version: reactorVersion
     compile group: 'org.springframework', name: 'spring-context', version: springFrameworkVersion
+    compile group: 'log4j', name: 'log4j', version: '1.2.17'
 
     testCompile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
 }

--- a/molr-mole-core/src/main/java/io/molr/mole/core/api/Mole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/api/Mole.java
@@ -104,6 +104,9 @@ public interface Mole {
      */
     Mono<MissionParameterDescription> parameterDescriptionOf(Mission mission);
 
+    // TODO Add javadoc
+    Flux<MissionLog> logsFor(MissionHandle handle);
+
     /**
      * Instructs the mission instance identified by the given handle to execute the given command on the given strand.
      * The allowed commands can be 'guessed' by using the information from {@link #statesFor(MissionHandle)}. However,

--- a/molr-mole-core/src/main/java/io/molr/mole/core/api/MoleWebApi.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/api/MoleWebApi.java
@@ -18,6 +18,7 @@ public final class MoleWebApi {
     public static final String INSTANCE_STATES_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/states";
     public static final String INSTANCE_OUTPUTS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/outputs";
     public static final String INSTANCE_REPRESENTATIONS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/representations";
+    public static final String INSTANCE_LOGS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/logs";
     public static final String INSTANTIATE_MISSION_PATH = MISSION_HEADER + "{" + MISSION_NAME + "}/instantiate";
     public static final String INSTANCE_INSTRUCT_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/{" + STRAND_ID + "}/instruct/{" + COMMAND_NAME+ "}";
     public static final String INSTANCE_INSTRUCT_ROOT_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/instructRoot/{" + COMMAND_NAME+ "}";
@@ -42,6 +43,10 @@ public final class MoleWebApi {
 
     public static String instanceRepresentationsUrl(String missionHandle){
         return  format(INSTANCE_HEADER + "%s/representations", missionHandle);
+    }
+
+    public static String instanceLogsUrl(String missionHandle){
+        return  format(INSTANCE_HEADER + "%s/logs", missionHandle);
     }
 
     public static String instantiateMission(String missionName){

--- a/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
@@ -119,6 +119,11 @@ public class LocalSuperMole implements Mole {
         return fromActiveMoleOrError(handle, m -> m.representationsFor(handle));
     }
 
+    @Override
+    public Flux<MissionLog> logsFor(MissionHandle handle) {
+        return fromActiveMoleOrError(handle, m -> m.logsFor(handle));
+    }
+
     private Mono<Mole> getMole(Mission mission) {
         Mole mole = missionMoles.get(mission);
         if (mole == null) {

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogAppender.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogAppender.java
@@ -1,0 +1,52 @@
+package io.molr.mole.core.logging;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionLog;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.Filter;
+import org.apache.log4j.spi.LoggingEvent;
+
+// TODO Add javadoc
+public class MissionLogAppender extends AppenderSkeleton {
+
+    public MissionLogAppender(MissionHandle handle) {
+        addFilter(new MissionHandleFilter(handle.id()));
+    }
+
+    @Override
+    protected void append(LoggingEvent event) {
+        if (headFilter.decide(event) == Filter.ACCEPT) {
+            MissionLog missionLog = (MissionLog) event.getMessage();
+            MissionLogHandler.publish(MissionHandle.ofId(missionLog.missionHandle()), missionLog);
+        }
+    }
+
+    @Override
+    public void close() {
+        clearFilters();
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    private static class MissionHandleFilter extends Filter {
+
+        private final String handleId;
+
+        public MissionHandleFilter(String handleId) {
+            this.handleId = handleId;
+        }
+
+        @Override
+        public int decide(LoggingEvent event) {
+            MissionLog missionLog = (MissionLog) event.getMessage();
+            if (handleId.equals(missionLog.missionHandle())) {
+                return ACCEPT;
+            } else {
+                return DENY;
+            }
+        }
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogHandler.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogHandler.java
@@ -1,0 +1,31 @@
+package io.molr.mole.core.logging;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionLog;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// TODO Add javadoc
+public class MissionLogHandler {
+    private static Map<MissionHandle, MissionLogger> missionToLogs = new ConcurrentHashMap<>();
+
+    public static void init(MissionHandle handle) {
+        if (!missionToLogs.containsKey(handle)) {
+            missionToLogs.put(handle, new MissionLogger(handle));
+        }
+    }
+
+    public static void publish(MissionHandle handle, MissionLog log) {
+        missionToLogs.get(handle).publish(log);
+    }
+
+    public static Flux<MissionLog> asStream(MissionHandle handle) {
+        return missionToLogs.get(handle).asStream();
+    }
+
+    public static MissionLogger get(MissionHandle handle) {
+        return missionToLogs.get(handle);
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogger.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/MissionLogger.java
@@ -1,0 +1,28 @@
+package io.molr.mole.core.logging;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionLog;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.ReplayProcessor;
+import reactor.core.scheduler.Schedulers;
+
+// TODO Add javadoc
+public class MissionLogger {
+    private ReplayProcessor<MissionLog> missionLogsSink;
+    private Flux<MissionLog> missionLogsStream;
+
+    public MissionLogger(MissionHandle handle) {
+        this.missionLogsSink = ReplayProcessor.cacheLast();
+        this.missionLogsStream = missionLogsSink.publishOn(Schedulers.newSingle("mission-logs-" + handle.id()));
+    }
+
+    public void publish(MissionLog msg) {
+        missionLogsSink.onNext(msg);
+    }
+
+    public Flux<MissionLog> asStream() {
+        return missionLogsStream;
+    }
+
+}
+

--- a/molr-mole-core/src/main/java/io/molr/mole/core/runnable/RunnableLeafsMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/runnable/RunnableLeafsMole.java
@@ -53,7 +53,7 @@ public class RunnableLeafsMole extends AbstractJavaMole {
 
 
     @Override
-    protected MissionExecutor executorFor(Mission mission, Map<String, Object> params) {
+    protected MissionExecutor executorFor(MissionHandle handle, Mission mission, Map<String, Object> params) {
         RunnableLeafsMission runnableLeafMission = missions.get(mission);
         TreeStructure treeStructure = runnableLeafMission.treeStructure();
         TreeTracker<Result> resultTracker = TreeTracker.create(treeStructure.missionRepresentation(), Result.UNDEFINED, Result::summaryOf);

--- a/molr-mole-core/src/main/java/io/molr/mole/core/single/SingleNodeMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/single/SingleNodeMole.java
@@ -1,6 +1,7 @@
 package io.molr.mole.core.single;
 
 import io.molr.commons.domain.Mission;
+import io.molr.commons.domain.MissionHandle;
 import io.molr.commons.domain.MissionParameterDescription;
 import io.molr.commons.domain.MissionRepresentation;
 import io.molr.mole.core.tree.AbstractJavaMole;
@@ -45,10 +46,10 @@ public class SingleNodeMole extends AbstractJavaMole {
     }
 
     @Override
-    protected MissionExecutor executorFor(Mission mission, Map<String, Object> params) {
+    protected MissionExecutor executorFor(MissionHandle handle, Mission mission, Map<String, Object> params) {
         SingleNodeMission<?> singleNodeMission = Optional.ofNullable(missions.get(mission))
                 .orElseThrow(() -> new IllegalArgumentException("Mole cannot handle mission '" + mission + "'."));
-        return new SingleNodeMissionExecutor<>(singleNodeMission, params);
+        return new SingleNodeMissionExecutor<>(handle, singleNodeMission, params);
     }
 
 }

--- a/molr-mole-core/src/main/resources/log4j.properties
+++ b/molr-mole-core/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=ALL, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold=WARN
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS}  %-4p %5L --- [%15.15t] %-40.40C : %m%n%x

--- a/molr-mole-remote/src/main/java/io/molr/mole/remote/rest/RestRemoteMole.java
+++ b/molr-mole-remote/src/main/java/io/molr/mole/remote/rest/RestRemoteMole.java
@@ -69,6 +69,12 @@ public class RestRemoteMole implements Mole {
                 .map(MissionRepresentationDto::toMissionRepresentation);
     }
 
+    @Override
+    public Flux<MissionLog> logsFor(MissionHandle handle) {
+        return clientUtils.flux(MoleWebApi.instanceLogsUrl(handle.id()), MissionLogDto.class)
+                .map(MissionLogDto::toMissionLog);
+    }
+
     /* Post requests */
 
     @Override

--- a/molr-mole-server/src/main/java/io/molr/mole/server/rest/MolrMoleRestService.java
+++ b/molr-mole-server/src/main/java/io/molr/mole/server/rest/MolrMoleRestService.java
@@ -65,6 +65,11 @@ public class MolrMoleRestService {
         return mole.representationsFor(MissionHandle.ofId(missionHandle)).map(MissionRepresentationDto::from);
     }
 
+    @GetMapping(path = INSTANCE_LOGS_PATH, produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<MissionLogDto> logsFor(@PathVariable(MISSION_HANDLE) String missionHandle) {
+        return mole.logsFor(MissionHandle.ofId(missionHandle)).map(MissionLogDto::from);
+    }
+
     @GetMapping(path = "/test-stream/{count}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<TestValueDto> testResponse(@PathVariable("count") int count) {
         return Flux.interval(Duration.of(1, ChronoUnit.SECONDS))


### PR DESCRIPTION
This fix exposes an endpoint to get log information for a mission under execution. Fixes #20 

WIP below tasks:
- Add javadoc
- Add Tests
- Evaluate and add more meaningful log statements to MissionExecutor implementations.