### PR TITLE
Add support for Mission Logs using Logback

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ reactorVersion=3.2.2.RELEASE
 guavaVersion=27.0-jre
 jUnitVersion=4.12
 assertJVersion=3.11.1
+logbackVersion=1.2.3
 
 # DEPLOYMENT PROPERTIES
 POM.groupId=io.molr

--- a/molr-commons/src/main/java/io/molr/commons/domain/MissionLog.java
+++ b/molr-commons/src/main/java/io/molr/commons/domain/MissionLog.java
@@ -1,0 +1,102 @@
+package io.molr.commons.domain;
+
+import io.molr.commons.domain.dto.MissionLogDto;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public final class MissionLog {
+    private final Date time;
+    private final MissionHandle missionHandle;
+    private final Strand strand;
+    private final String block;
+    private final String message;
+
+    public final static DateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss:SSS");
+
+    private MissionLog(Builder builder) {
+        this.time = builder.time;
+        this.missionHandle = builder.missionHandle;
+        this.strand = builder.strand;
+        this.block = builder.block;
+        this.message = builder.message;
+    }
+
+    public static Builder from(String handleId) {
+        return new Builder(MissionHandle.ofId(handleId));
+    }
+
+    public Date time() {
+        return time;
+    }
+
+    public MissionHandle missionHandle() {
+        return missionHandle;
+    }
+
+    public Strand strand() {
+        return strand;
+    }
+
+    public String block() {
+        return block;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return MissionLogDto.from(this).toString();
+    }
+
+    public static class Builder {
+
+        private Date time;
+        private MissionHandle missionHandle;
+        private Strand strand;
+        private String block;
+        private String message;
+
+        private Builder(MissionHandle handle) {
+            this.missionHandle = handle;
+        }
+
+        public Builder time(long time) {
+            this.time = new Date(time);
+            return this;
+        }
+
+        public Builder time(Date time) {
+            this.time = time;
+            return this;
+        }
+
+        public Builder strand(Strand strand) {
+            this.strand = strand;
+            return this;
+        }
+
+        public Builder strand(String strandId) {
+            this.strand = strand == null ? null : Strand.ofId(strandId);
+            return this;
+        }
+
+        public Builder block(String block) {
+            this.block = block;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public MissionLog build() {
+            MissionLog log = new MissionLog(this);
+            return log;
+        }
+    }
+}

--- a/molr-commons/src/main/java/io/molr/commons/domain/dto/MissionLogDto.java
+++ b/molr-commons/src/main/java/io/molr/commons/domain/dto/MissionLogDto.java
@@ -1,0 +1,57 @@
+package io.molr.commons.domain.dto;
+
+import io.molr.commons.domain.MissionLog;
+
+import java.text.ParseException;
+
+public class MissionLogDto {
+
+    public final String time;
+    public final String missionHandle;
+    public final String strandId;
+    public final String block;
+    public final String message;
+
+    public MissionLogDto(String time, String missionHandle, String strandId, String block, String message) {
+        this.time = time;
+        this.missionHandle = missionHandle;
+        this.strandId = strandId;
+        this.block = block;
+        this.message = message;
+    }
+
+    public MissionLogDto() {
+        this.time = null;
+        this.missionHandle = null;
+        this.strandId = null;
+        this.block = null;
+        this.message = null;
+    }
+
+    public static final MissionLogDto from(MissionLog missionLog) {
+        return new MissionLogDto(missionLog.time() == null? null : MissionLog.dateFormatter.format(missionLog.time()),
+                missionLog.missionHandle().id(),
+                missionLog.strand() == null ? null : missionLog.strand().id(),
+                missionLog.block(), missionLog.message());
+    }
+
+    public MissionLog toMissionLog() {
+        try {
+            return MissionLog.from(missionHandle).time(MissionLog.dateFormatter.parse(time)).strand(strandId).block(block)
+                    .message(message).build();
+        } catch (ParseException e) {
+            return MissionLog.from(missionHandle).strand(strandId).block(block).message(message).build();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MissionLogDto{" +
+                "time='" + time + '\'' +
+                ", missionHandle='" + missionHandle + '\'' +
+                ", strandId='" + strandId + '\'' +
+                ", block='" + block + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/molr-mole-core/build.gradle
+++ b/molr-mole-core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     compile group: 'io.projectreactor', name: 'reactor-core', version: reactorVersion
     compile group: 'org.springframework', name: 'spring-context', version: springFrameworkVersion
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
 
     testCompile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
 }

--- a/molr-mole-core/src/main/java/io/molr/mole/core/api/Mole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/api/Mole.java
@@ -79,6 +79,9 @@ public interface Mole {
      */
     Flux<MissionRepresentation> representationsFor(MissionHandle handle);
 
+    // TODO Add javadoc
+    Flux<MissionLog> logsFor(MissionHandle handle);
+
     /**
      * Retrieves the initial (!) representation of a mission, meaning when the mission is not instantiated/running. This
      * representation contains for example the tree structure of the mission. In many (or even most) cases, this

--- a/molr-mole-core/src/main/java/io/molr/mole/core/api/MoleWebApi.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/api/MoleWebApi.java
@@ -18,6 +18,7 @@ public final class MoleWebApi {
     public static final String INSTANCE_STATES_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/states";
     public static final String INSTANCE_OUTPUTS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/outputs";
     public static final String INSTANCE_REPRESENTATIONS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/representations";
+    public static final String INSTANCE_LOGS_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/logs";
     public static final String INSTANTIATE_MISSION_PATH = MISSION_HEADER + "{" + MISSION_NAME + "}/instantiate";
     public static final String INSTANCE_INSTRUCT_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/{" + STRAND_ID + "}/instruct/{" + COMMAND_NAME+ "}";
     public static final String INSTANCE_INSTRUCT_ROOT_PATH = INSTANCE_HEADER + "{" + MISSION_HANDLE + "}/instructRoot/{" + COMMAND_NAME+ "}";
@@ -42,6 +43,10 @@ public final class MoleWebApi {
 
     public static String instanceRepresentationsUrl(String missionHandle){
         return  format(INSTANCE_HEADER + "%s/representations", missionHandle);
+    }
+
+    public static String instanceLogsUrl(String missionHandle){
+        return  format(INSTANCE_HEADER + "%s/logs", missionHandle);
     }
 
     public static String instantiateMission(String missionName){

--- a/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/local/LocalSuperMole.java
@@ -119,6 +119,11 @@ public class LocalSuperMole implements Mole {
         return fromActiveMoleOrError(handle, m -> m.representationsFor(handle));
     }
 
+    @Override
+    public Flux<MissionLog> logsFor(MissionHandle handle) {
+        return fromActiveMoleOrError(handle, m -> m.logsFor(handle));
+    }
+
     private Mono<Mole> getMole(Mission mission) {
         Mole mole = missionMoles.get(mission);
         if (mole == null) {

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/LogAppenderConfiguration.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/LogAppenderConfiguration.java
@@ -1,0 +1,107 @@
+package io.molr.mole.core.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.molr.mole.core.logging.consumer.LogConsumer;
+import io.molr.mole.core.logging.consumer.LogConsumerFactory;
+import io.molr.mole.core.logging.data.LogData;
+import io.molr.mole.core.logging.filter.RunningMissionFilter;
+import io.molr.mole.core.logging.publisher.LogPublisher;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+// TODO Add javadoc
+public class LogAppenderConfiguration {
+
+    private final static String propertiesFile = "logAppender.properties";
+
+    public LogAppenderConfiguration() throws IOException, IllegalAccessException, ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        configureAppender(getLogProperties());
+    }
+
+    private Properties getLogProperties() throws IOException {
+        Properties properties = new Properties();
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        InputStream resourceStream = loader.getResourceAsStream(propertiesFile);
+        properties.load(resourceStream);
+        return properties;
+    }
+
+    private void configureAppender(Properties properties) throws IllegalAccessException, InstantiationException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
+        String appenders = properties.getProperty("log.appender");
+        if (StringUtils.isEmpty(appenders)) {
+            return;
+        }
+
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Logger rootLogger = (Logger) context.getLogger(Logger.ROOT_LOGGER_NAME);
+
+        List<String> appenderNames = Arrays.asList(appenders.split(","));
+        for (String appenderName : appenderNames) {
+            loadAppender(context, rootLogger, properties, appenderName);
+        }
+    }
+
+    private void loadAppender(LoggerContext context, Logger rootLogger, Properties properties, String appenderName) throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        String appenderClassName = properties.getProperty("log.appender." + appenderName);
+        String dataClassName = properties.getProperty("log.appender." + appenderName + ".data");
+        String publisherClassName = properties.getProperty("log.appender." + appenderName + ".publisher");
+        if (StringUtils.isEmpty(appenderClassName) || StringUtils.isEmpty(dataClassName) || StringUtils.isEmpty(publisherClassName)) {
+            return;
+        }
+
+        LogData data = (LogData) Class.forName(dataClassName).newInstance();
+        LogPublisher publisher = (LogPublisher) Class.forName(publisherClassName).newInstance();
+        Appender<ILoggingEvent> appender = (Appender<ILoggingEvent>) Class.forName(appenderClassName).getConstructor(LogData.class, LogPublisher.class).newInstance(data, publisher);
+
+        addConsumers(properties, appenderName, publisher);
+
+        addFilters(properties, appenderName, appender);
+
+        appender.setName(appenderName);
+        appender.setContext(context);
+        appender.start();
+
+        rootLogger.addAppender(appender);
+    }
+
+    private void addFilters(Properties properties, String appenderName, Appender<ILoggingEvent> appender) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        String filters = properties.getProperty("log.appender." + appenderName + ".filter");
+        if (StringUtils.isEmpty(filters)) {
+            return;
+        }
+
+        List<String> filterNames = Arrays.asList(filters.split(","));
+        for (String filterName : filterNames) {
+            String filterClassName = properties.getProperty("log.appender." + appenderName + ".filter." + filterName);
+            if (!StringUtils.isEmpty(filterClassName)) {
+                RunningMissionFilter filter = (RunningMissionFilter) Class.forName(filterClassName).newInstance();
+                appender.addFilter(filter);
+            }
+        }
+    }
+
+    private void addConsumers(Properties properties, String appenderName, LogPublisher publisher) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        String consumers = properties.getProperty("log.appender." + appenderName + ".consumer");
+        if (StringUtils.isEmpty(consumers)) {
+            return;
+        }
+        List<String> consumerNames = Arrays.asList(consumers.split(","));
+        for (String consumerName : consumerNames) {
+            String consumerClassName = properties.getProperty("log.appender." + appenderName + ".consumer." + consumerName);
+            if (!StringUtils.isEmpty(consumerClassName)) {
+                LogConsumer consumer = LogConsumerFactory.consumer(Class.forName(consumerClassName));
+                publisher.addConsumer(consumer);
+            }
+        }
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/appender/LogAppender.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/appender/LogAppender.java
@@ -1,0 +1,24 @@
+package io.molr.mole.core.logging.appender;
+
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import io.molr.mole.core.logging.data.LogData;
+import io.molr.mole.core.logging.publisher.LogPublisher;
+
+// TODO Add javadoc
+public class LogAppender extends AppenderBase<ILoggingEvent> {
+
+    private LogData data;
+    private LogPublisher publisher;
+
+    public LogAppender(LogData data, LogPublisher publisher) {
+        this.data = data;
+        this.publisher = publisher;
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        publisher.publish(data.extract(event));
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/LogConsumer.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/LogConsumer.java
@@ -1,0 +1,10 @@
+package io.molr.mole.core.logging.consumer;
+
+import reactor.core.publisher.Flux;
+
+import java.util.Observer;
+
+// TODO Add javadoc
+public interface LogConsumer<U, V> extends Observer {
+    Flux<U> asStream(V t);
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/LogConsumerFactory.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/LogConsumerFactory.java
@@ -1,0 +1,19 @@
+package io.molr.mole.core.logging.consumer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// TODO Add javadoc
+public class LogConsumerFactory {
+    private static Map<Class<?>, LogConsumer> logConsumerMap = new ConcurrentHashMap<>();
+
+    public static <T> LogConsumer consumer(Class<T> clz) throws IllegalAccessException, InstantiationException {
+        synchronized (logConsumerMap) {
+            if (!logConsumerMap.containsKey(clz)) {
+                LogConsumer logConsumer = (LogConsumer) clz.newInstance();
+                logConsumerMap.put(clz, logConsumer);
+            }
+            return logConsumerMap.get(clz);
+        }
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/RunningMissionLogConsumer.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/consumer/RunningMissionLogConsumer.java
@@ -1,0 +1,28 @@
+package io.molr.mole.core.logging.consumer;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionLog;
+import io.molr.mole.core.logging.stream.LogStream;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+import java.util.Observable;
+import java.util.concurrent.ConcurrentHashMap;
+
+// TODO Add javadoc
+public class RunningMissionLogConsumer implements LogConsumer<MissionLog, MissionHandle> {
+
+    Map<MissionHandle, LogStream<MissionLog>> missionToStream = new ConcurrentHashMap<>();
+
+    @Override
+    public void update(Observable o, Object arg) {
+        MissionLog missionLog = (MissionLog) arg;
+        missionToStream.computeIfAbsent(missionLog.missionHandle(), m -> new LogStream<>());
+        missionToStream.get(missionLog.missionHandle()).publish(missionLog);
+    }
+
+    @Override
+    public Flux<MissionLog> asStream(MissionHandle handle) {
+        return missionToStream.containsKey(handle) ? missionToStream.get(handle).asStream() : null;
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/data/LogData.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/data/LogData.java
@@ -1,0 +1,8 @@
+package io.molr.mole.core.logging.data;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+// TODO Add javadoc
+public interface LogData {
+    Object extract(ILoggingEvent event);
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/data/RunningMissionData.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/data/RunningMissionData.java
@@ -1,0 +1,16 @@
+package io.molr.mole.core.logging.data;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import io.molr.commons.domain.MissionLog;
+
+import java.util.Map;
+
+// TODO Add Javadoc
+public class RunningMissionData implements LogData {
+    @Override
+    public Object extract(ILoggingEvent event) {
+        Map<String, String> mdc = event.getMDCPropertyMap();
+        return MissionLog.from(mdc.get("missionHandle")).time(event.getTimeStamp()).strand(mdc.get("strand"))
+                .block(mdc.get("block")).message(event.getFormattedMessage()).build();
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/filter/RunningMissionFilter.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/filter/RunningMissionFilter.java
@@ -1,0 +1,15 @@
+package io.molr.mole.core.logging.filter;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import org.springframework.util.StringUtils;
+
+// TODO Add javadoc
+public class RunningMissionFilter extends Filter<ILoggingEvent> {
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        return StringUtils.isEmpty(event.getMDCPropertyMap().get("missionHandle")) ? FilterReply.DENY : FilterReply.ACCEPT;
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/publisher/LogPublisher.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/publisher/LogPublisher.java
@@ -1,0 +1,17 @@
+package io.molr.mole.core.logging.publisher;
+
+import io.molr.mole.core.logging.consumer.LogConsumer;
+
+import java.util.Observable;
+
+// TODO Add javadoc
+public class LogPublisher extends Observable {
+    public void addConsumer(LogConsumer consumer) {
+        addObserver(consumer);
+    }
+
+    public void publish(Object msg) {
+        setChanged();
+        notifyObservers(msg);
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/logging/stream/LogStream.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/logging/stream/LogStream.java
@@ -1,0 +1,24 @@
+package io.molr.mole.core.logging.stream;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.ReplayProcessor;
+import reactor.core.scheduler.Schedulers;
+
+// TODO Add javadoc
+public class LogStream<T> {
+    private ReplayProcessor<T> logsSink;
+    private Flux<T> logsStream;
+
+    public LogStream() {
+        this.logsSink = ReplayProcessor.cacheLast();
+        this.logsStream = logsSink.publishOn(Schedulers.elastic());
+    }
+
+    public void publish(T msg) {
+        logsSink.onNext(msg);
+    }
+
+    public Flux<T> asStream() {
+        return logsStream;
+    }
+}

--- a/molr-mole-core/src/main/java/io/molr/mole/core/runnable/RunnableLeafsMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/runnable/RunnableLeafsMole.java
@@ -53,7 +53,7 @@ public class RunnableLeafsMole extends AbstractJavaMole {
 
 
     @Override
-    protected MissionExecutor executorFor(Mission mission, Map<String, Object> params) {
+    protected MissionExecutor executorFor(MissionHandle handle, Mission mission, Map<String, Object> params) {
         RunnableLeafsMission runnableLeafMission = missions.get(mission);
         TreeStructure treeStructure = runnableLeafMission.treeStructure();
         TreeTracker<Result> resultTracker = TreeTracker.create(treeStructure.missionRepresentation(), Result.UNDEFINED, Result::summaryOf);

--- a/molr-mole-core/src/main/java/io/molr/mole/core/single/SingleNodeMole.java
+++ b/molr-mole-core/src/main/java/io/molr/mole/core/single/SingleNodeMole.java
@@ -1,8 +1,6 @@
 package io.molr.mole.core.single;
 
-import io.molr.commons.domain.Mission;
-import io.molr.commons.domain.MissionParameterDescription;
-import io.molr.commons.domain.MissionRepresentation;
+import io.molr.commons.domain.*;
 import io.molr.mole.core.tree.AbstractJavaMole;
 import io.molr.mole.core.tree.MissionExecutor;
 
@@ -45,10 +43,9 @@ public class SingleNodeMole extends AbstractJavaMole {
     }
 
     @Override
-    protected MissionExecutor executorFor(Mission mission, Map<String, Object> params) {
+    protected MissionExecutor executorFor(MissionHandle handle, Mission mission, Map<String, Object> params) {
         SingleNodeMission<?> singleNodeMission = Optional.ofNullable(missions.get(mission))
                 .orElseThrow(() -> new IllegalArgumentException("Mole cannot handle mission '" + mission + "'."));
-        return new SingleNodeMissionExecutor<>(singleNodeMission, params);
+        return new SingleNodeMissionExecutor<>(handle, singleNodeMission, params);
     }
-
 }

--- a/molr-mole-core/src/main/resources/logAppender.properties
+++ b/molr-mole-core/src/main/resources/logAppender.properties
@@ -1,0 +1,9 @@
+log.appender=runningMission
+
+log.appender.runningMission=io.molr.mole.core.logging.appender.LogAppender
+log.appender.runningMission.data=io.molr.mole.core.logging.data.RunningMissionData
+log.appender.runningMission.publisher=io.molr.mole.core.logging.publisher.LogPublisher
+log.appender.runningMission.filter=runningMissionFilter
+log.appender.runningMission.filter.runningMissionFilter=io.molr.mole.core.logging.filter.RunningMissionFilter
+log.appender.runningMission.consumer=runningMissionLogConsumer
+log.appender.runningMission.consumer.runningMissionLogConsumer=io.molr.mole.core.logging.consumer.RunningMissionLogConsumer

--- a/molr-mole-remote/src/main/java/io/molr/mole/remote/rest/RestRemoteMole.java
+++ b/molr-mole-remote/src/main/java/io/molr/mole/remote/rest/RestRemoteMole.java
@@ -69,6 +69,12 @@ public class RestRemoteMole implements Mole {
                 .map(MissionRepresentationDto::toMissionRepresentation);
     }
 
+    @Override
+    public Flux<MissionLog> logsFor(MissionHandle handle) {
+        return clientUtils.flux(MoleWebApi.instanceLogsUrl(handle.id()), MissionLogDto.class)
+                .map(MissionLogDto::toMissionLog);
+    }
+
     /* Post requests */
 
     @Override

--- a/molr-mole-server/src/main/java/io/molr/mole/server/main/DemoMolrServerMain.java
+++ b/molr-mole-server/src/main/java/io/molr/mole/server/main/DemoMolrServerMain.java
@@ -1,6 +1,7 @@
 package io.molr.mole.server.main;
 
 import io.molr.mole.core.conf.LocalSuperMoleConfiguration;
+import io.molr.mole.core.logging.LogAppenderConfiguration;
 import io.molr.mole.server.conf.SingleMoleRestServiceConfiguration;
 import io.molr.mole.server.demo.DemoConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -8,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import({LocalSuperMoleConfiguration.class, SingleMoleRestServiceConfiguration.class, DemoConfiguration.class})
+@Import({LogAppenderConfiguration.class, LocalSuperMoleConfiguration.class, SingleMoleRestServiceConfiguration.class, DemoConfiguration.class})
 public class DemoMolrServerMain {
 
     public static void main(String... args) {

--- a/molr-mole-server/src/main/java/io/molr/mole/server/rest/MolrMoleRestService.java
+++ b/molr-mole-server/src/main/java/io/molr/mole/server/rest/MolrMoleRestService.java
@@ -65,6 +65,11 @@ public class MolrMoleRestService {
         return mole.representationsFor(MissionHandle.ofId(missionHandle)).map(MissionRepresentationDto::from);
     }
 
+    @GetMapping(path = INSTANCE_LOGS_PATH, produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<MissionLogDto> logsFor(@PathVariable(MISSION_HANDLE) String missionHandle) {
+        return mole.logsFor(MissionHandle.ofId(missionHandle)).map(MissionLogDto::from);
+    }
+
     @GetMapping(path = "/test-stream/{count}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<TestValueDto> testResponse(@PathVariable("count") int count) {
         return Flux.interval(Duration.of(1, ChronoUnit.SECONDS))


### PR DESCRIPTION
This fix exposes an endpoint to get log information for a mission under execution. I've used Logback implementation of Slf4j API to use appenders which will be able to filter required events and publish them to consumers. Information can be added to MDC just before the log event is sent and this information will be extracted by the appender.

WIP below tasks:
- Add javadoc
- Add Tests
- Evaluate and add more meaningful log statements to implementations of MissionExecutor, StrandExecutor and LeafExecutor. (Currently, I've handled MDC statements in SingleNodeMissionExecutor only.) 

Fixes #20 